### PR TITLE
Regex fix

### DIFF
--- a/PlaygroundRuntime.swift
+++ b/PlaygroundRuntime.swift
@@ -45,27 +45,27 @@ class LogRecord {
   }
 }
 
-func $builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+func __builtin_log<T>(_ object : T, _ name : String, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
   return LogRecord(api:"$builtin_log", object:object, name:name, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+func __builtin_log_with_id<T>(_ object : T, _ name : String, _ id : Int, _ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
   return LogRecord(api:"$builtin_log", object:object, name:name, id:id, range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+func __builtin_log_scope_entry(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
   return LogRecord(api:"$builtin_log_scope_entry", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+func __builtin_log_scope_exit(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
   return LogRecord(api:"$builtin_log_scope_exit", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
+func __builtin_postPrint(_ sl : Int, _ el : Int, _ sc : Int, _ ec: Int) -> AnyObject? {
   return LogRecord(api:"$builtin_postPrint", range : SourceRange(sl:sl, el:el, sc:sc, ec:ec))
 }
 
-func $builtin_send_data(_ object:AnyObject?) {
+func __builtin_send_data(_ object:AnyObject?) {
   let record = object as! LogRecord
   if record.api != "$builtin_log" {
       return

--- a/runner.sh
+++ b/runner.sh
@@ -61,7 +61,7 @@ if [[ $? == 0 ]]; then
     # Run on the simulator by default.
     # We build for x86_64, so use the first iPhone that isn't a 5.
     # Find a device that is either (booted) or (shutdown)
-    DEVICE=$( xcrun simctl list | grep 'iPhone [^5] .*(.*).*(.*)' | perl -pe 's/(.*\()(.*)\)+ (.*)/\2/' | sed -n 1p )
+    DEVICE=$(xcrun simctl list | grep 'iPhone [^5] .*(.*).*(.*)' | perl -ne 'print "$&\n" if /([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})/' | sed -n 1p )
     xcrun simctl spawn $DEVICE $PWD/main
 else
     # Build and run for the host target


### PR DESCRIPTION
I was receiving an error 'Invalid device: Shutdown'. The output from `xcrun simctl list` must have changed since the original regex was written. I have updated it so it matches against the standard simulator UDID format, this may be different for XS devices(?). 