### PR TITLE
Fix grep warning when running on non-iOS targets

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Check contents.xcplayground for ios
-grep -q "target-platform='ios'" "$SRC_ROOT/contents.xcplayground"
+grep -q "target-platform='ios'" "$SRC_ROOT/contents.xcplayground" &>/dev/null
 if [[ $? == 0 ]]; then
     XCODE_APP_DEVELOPER_DIR=$( xcode-select -p )
     # Build and run for iOS


### PR DESCRIPTION
This is necessary for [`swift-playground-mode` for emacs](https://gitlab.com/michael.sanders/swift-playground-mode) so it doesn't pop up with an extraneous error when running the script.